### PR TITLE
Add CI for Linux and Mac OS X build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "8"
+os:
+  - linux
+  - osx
+  


### PR DESCRIPTION
Added Travis CI to test the build on Linux and Mac OS X, demonstrates issue #2 

Build succeeds on Mac OS X but fails on Linux (e.g. [https://travis-ci.org/kdkeyser/reason-mui-withstyles-ppx/builds/481529486](https://travis-ci.org/kdkeyser/reason-mui-withstyles-ppx/builds/481529486) )

Root cause is that the Mac OS X file system, while case preserving, is not case sensitive when opening a file. On Linux, opening a file is case sensitive. Best practice seems to be to use all lowercase for Reason/Ocaml filenames.